### PR TITLE
Update TM1 Rule.sublime-syntax

### DIFF
--- a/syntax/TM1 Rule.sublime-syntax
+++ b/syntax/TM1 Rule.sublime-syntax
@@ -15,7 +15,7 @@ contexts:
   - match: (?i)(feeders|feedstrings|skipcheck)(;)
     scope: constant.language
 
-  - match: (!)(.*?)(?=([^\w\s]))
+  - match: (!\w+)
     scope: variable.parameter
 
   - match: (')


### PR DESCRIPTION
Updated regex to highlight variable on rules syntax to work when break lines e.g.: DB(sCube
   ,!sEle1
   ,!sEle2
   ,!sEleN );